### PR TITLE
Karma: Allow multiple nicks as argument

### DIFF
--- a/modules/karma.py
+++ b/modules/karma.py
@@ -67,7 +67,7 @@ def sendmsg(sender, recip, text):
         nicks = text.strip().split(" ")[1:]
         try:
             items = [(k, "%s(%d)" % (n, k)) for n, k in karma.items() if n in nicks]
-            return ", ".join(map(itemgetter(1), sorted(items, reverse=True)))
+            return ", ".join(map(lambda x:x[1], sorted(items, reverse=True)))
         except:
             return "Ma di che parli?"
     elif (text.endswith('++') and len(text.split(' ')) == 1):

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -64,9 +64,10 @@ def sendmsg(sender, recip, text):
                 (", ".join(["%s(%d)" % (n, k) for (k, n) in rank_pos]),
                  ", ".join(["%s(%d)" % (n, k) for (k, n) in rank_neg])))
     elif text.startswith(config['control'] + "karma "):
-        nick = text.split(" ", 1)[1].strip()
+        nicks = test.strip().split(" ")[1:]
         try:
-            return "%s: %d" % (nick, karma[nick])
+            items = [(k, "%s(%d)" % (n, k)) for karma.items() if n in nicks]
+            return ", ".join(map(itemgetter(1), sorted(items, reverse=True)))
         except:
             return "Ma di che parli?"
     elif (text.endswith('++') and len(text.split(' ')) == 1):

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -64,9 +64,9 @@ def sendmsg(sender, recip, text):
                 (", ".join(["%s(%d)" % (n, k) for (k, n) in rank_pos]),
                  ", ".join(["%s(%d)" % (n, k) for (k, n) in rank_neg])))
     elif text.startswith(config['control'] + "karma "):
-        nicks = test.strip().split(" ")[1:]
+        nicks = text.strip().split(" ")[1:]
         try:
-            items = [(k, "%s(%d)" % (n, k)) for karma.items() if n in nicks]
+            items = [(k, "%s(%d)" % (n, k)) for n, k in karma.items() if n in nicks]
             return ", ".join(map(itemgetter(1), sorted(items, reverse=True)))
         except:
             return "Ma di che parli?"


### PR DESCRIPTION
Example: Suppose `karma == {'foo': -1, 'bar': 15}`, then as before

```
<salto-edit> !karma bar
```

is answered by the bot with bar's karma

```
<LtData> bar(15)
```

Now, it's also possible to compare the karma of "bar" and "foo" in one command line:

```
<salto-edit> !karma foo bar
<LtData> bar(15), foo(-1)
```
