### PR TITLE
Karma: Don't create duplicate entries for names that differ only in lower- and uppercase

### DIFF
--- a/modules/karma.py
+++ b/modules/karma.py
@@ -70,28 +70,24 @@ def sendmsg(sender, recip, text):
         except:
             return "Ma di che parli?"
     elif (text.endswith('++') and len(text.split(' ')) == 1):
-        nick = text[:-2]
-        if nick == config['nickname']:
-            karma[nick] = readval(nick) + 1
-            result = "Grazie per la tua stima"
-        elif nick == sender:
-            result = "Un po' autoreferenziale, non credi?"
-        else:
-            karma[nick] = readval(nick) + 1
-            result = "Prendo nota. %s: %d" % (nick, karma[nick])
-        save()
-        return result
+        return vote(text[:-2])
     elif (text.endswith('--') and len(text.split(' ')) == 1):
-        nick = text[:-2]
-        if nick == config['nickname']:
-            result = "Nah, non credo di volerlo fare"
-        else:
-            karma[nick] = readval(nick) - 1
-            result = "Prendo nota. %s: %d" % (nick, karma[nick])
-        save()
-        return result
+        return vote(text[:-2], -1)
     return None
 
+def vote(nick, delta=1):
+    if nick == config['nickname'] and delta > 0:
+        karma[nick] = readval(nick) + delta
+        result = "Grazie per la tua stima"
+    elif nick == config['nickname'] and delta <= 0:
+        result = "Nah, non credo di volerlo fare"
+    elif nick == sender and delta > 0:
+        result = "Un po' autoreferenziale, non credi?"
+    else:
+        karma[nick] = readval(nick) + delta
+        result = "Prendo nota. %s: %d" % (nick, karma[nick])
+    save()
+    return result
 
 def help():
     return ".karma per vedere la classifica, .karma nickname per vedere il karma della persona, nickname++ o nickname-- per aumentarlo o diminuirlo"

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -19,6 +19,7 @@
 
 import sys
 import os
+import json
 config = {}
 karma = {}
 
@@ -28,28 +29,22 @@ def init():
 
 
 def load():
+    global karma
     f = file("%s/karma" % config['files'])
-    while True:
-        l = f.readline().strip()
-        if len(l) == 0:
-            return
-        parts = l.split('#', 1)
-        karma[parts[0]] = int(parts[1])
+    karma = json.load(f)
     f.close()
 
 
 def readval(nickname):
     try:
-        return karma[nickname]
+        return karma[nickname.lower()]
     except:
-        return 0
+        return (nickname, 0)
 
 
 def save():
     f = file("%s/karma" % config['files'], "w")
-    for i in karma:
-        f.write("%s#%d" % (i, karma[i]))
-        f.write("\n")
+    json.dump(f)
     f.close()
     pass
 
@@ -88,13 +83,10 @@ def vote(nick, delta=1):
         result = "Grazie per la tua stima"
     else:
         result = "Prendo nota."
-    entry = filter(lambda n: n.lower() == nick.lower, karma.keys())
-    if entry:
-        entry = entry[0]
-    else:
-        entry = nick
-    karma[entry] = readval(entry) + delta
-    result = "%s %s: %d" % (result, entry, karma[entry])
+    r, k = readval(nick)
+    k_ = k + delta
+    karma[nick.lower()] = (r, k_)
+    result = "%s %s: %d" % (result, r, k_)
     save()
     return result
 

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -70,18 +70,22 @@ def sendmsg(sender, recip, text):
         except:
             return "Ma di che parli?"
     elif (text.endswith('++') and len(text.split(' ')) == 1):
-        return vote(text[:-2])
+        nick = text[:-2]
+        if nick.lower() == sender.lower():
+            return "Un po' autoreferenziale, non credi?"
+        else:
+            return vote(nick)
     elif (text.endswith('--') and len(text.split(' ')) == 1):
-        return vote(text[:-2], -1)
+        nick = text[:-2]
+        if nick.lower() == config['nickname'].lower() and delta <= 0:
+            return "Nah, non credo di volerlo fare"
+        else:
+            return vote(nick, -1)
     return None
 
 def vote(nick, delta=1):
     if nick.lower() == config['nickname'].lower() and delta > 0:
         result = "Grazie per la tua stima"
-    elif nick.lower() == config['nickname'].lower() and delta <= 0:
-        return "Nah, non credo di volerlo fare"
-    elif nick.lower() == sender.lower() and delta > 0:
-        return "Un po' autoreferenziale, non credi?"
     else:
         result = "Prendo nota."
     entry = filter(lambda n: n.lower() == nick.lower, karma.keys())

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -77,15 +77,15 @@ def sendmsg(sender, recip, text):
 
 def vote(nick, delta=1):
     if nick == config['nickname'] and delta > 0:
-        karma[nick] = readval(nick) + delta
         result = "Grazie per la tua stima"
     elif nick == config['nickname'] and delta <= 0:
-        result = "Nah, non credo di volerlo fare"
+        return "Nah, non credo di volerlo fare"
     elif nick == sender and delta > 0:
-        result = "Un po' autoreferenziale, non credi?"
+        return "Un po' autoreferenziale, non credi?"
     else:
-        karma[nick] = readval(nick) + delta
-        result = "Prendo nota. %s: %d" % (nick, karma[nick])
+        result = "Prendo nota."
+    karma[nick] = readval(nick) + delta
+    result = "%s %s: %d" % (result, nick, karma[nick])
     save()
     return result
 

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -76,16 +76,21 @@ def sendmsg(sender, recip, text):
     return None
 
 def vote(nick, delta=1):
-    if nick == config['nickname'] and delta > 0:
+    if nick.lower() == config['nickname'].lower() and delta > 0:
         result = "Grazie per la tua stima"
-    elif nick == config['nickname'] and delta <= 0:
+    elif nick.lower() == config['nickname'].lower() and delta <= 0:
         return "Nah, non credo di volerlo fare"
-    elif nick == sender and delta > 0:
+    elif nick.lower() == sender.lower() and delta > 0:
         return "Un po' autoreferenziale, non credi?"
     else:
         result = "Prendo nota."
-    karma[nick] = readval(nick) + delta
-    result = "%s %s: %d" % (result, nick, karma[nick])
+    entry = filter(lambda n: n.lower() == nick.lower, karma.keys())
+    if entry:
+        entry = entry[0]
+    else:
+        entry = nick
+    karma[entry] = readval(entry) + delta
+    result = "%s %s: %d" % (result, entry, karma[entry])
     save()
     return result
 

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -71,7 +71,7 @@ def sendmsg(sender, recip, text):
             return "Ma di che parli?"
     elif (text.endswith('++') and len(text.split(' ')) == 1):
         nick = text[:-2]
-        if karma == config['nickname']:
+        if nick == config['nickname']:
             karma[nick] = readval(nick) + 1
             result = "Grazie per la tua stima"
         elif nick == sender:


### PR DESCRIPTION
Suppose someone upvoted "LtWorf" for the first time like so

```
<someone> LtWorf++
<LtData> Prendo nota. LtWorf(1)
```

And later someone upvotes "ltworf" because she is too lazy to spell LtWorf's nickname right, then

```
<someone> ltworf++
<LtData> Prendo nota. LtWorf(2)
```

and the updated database will not contain the key "ltworf" but "LtWorf" with an incremented karma counter.
