### PR TITLE
Notify users of new mail when changing nick

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -78,6 +78,20 @@ def onjoin(nick, channel):
             pass
 
 
+def onnick(nick):
+    '''Called when a user changes her nickname in one of the
+    channels that the bot is participating in.
+    
+    The main loop handles RFC 1459 NICK messages by calling
+    this method which forwards the event to each module that
+    defines an `onjoin` method.'''
+    for i in modules_list:
+        try:
+            i.onnick(nick)
+        except AttributeError:
+            pass
+
+
 def join(channels):
     '''Joins a list of channels'''
     for i in channels:
@@ -181,6 +195,9 @@ def main():
             nick, _, channel = data.split(' ', 3)
             nick = nick.split('!')[0].replace(':', '')
             onjoin(nick, channel)
+        elif data.find('NICK') != -1:
+            _, _, nick = data.split(' ', 3)
+            onnick(nick)
 
 if __name__ == '__main__':
     loadconf()

--- a/bot.py
+++ b/bot.py
@@ -78,7 +78,7 @@ def onjoin(nick, channel):
             pass
 
 
-def onnick(nick):
+def onnick(oldnick, newnick):
     '''Called when a user changes her nickname in one of the
     channels that the bot is participating in.
     
@@ -87,7 +87,7 @@ def onnick(nick):
     defines an `onjoin` method.'''
     for i in modules_list:
         try:
-            i.onnick(nick)
+            i.onnick(oldnick, newnick)
         except AttributeError:
             pass
 
@@ -196,8 +196,9 @@ def main():
             nick = nick.split('!')[0].replace(':', '')
             onjoin(nick, channel)
         elif data.find('NICK') != -1:
-            _, _, nick = data.split(' ', 3)
-            onnick(nick)
+            oldnick, _, newnick = data.split(' ', 3)
+            oldnick = oldnick.split('!')[0].replace(':', '')
+            onnick(oldnick, newnick)
 
 if __name__ == '__main__':
     loadconf()

--- a/modules/mail.py
+++ b/modules/mail.py
@@ -85,10 +85,18 @@ def sendmsg(source, dest, text):
                 return "mail: mail sent."
 
 
-def onjoin(nick, _):
+def checkmail(nick):
     mboxp = openmbox(nick)
     if mboxp and json.load(mboxp):
         privmsg(nick, "You got mail!")
+
+
+def onjoin(nick, _):
+    checkmail(nick)
+
+
+def onnick(nick):
+    checkmail(nick)
 
 
 def help():

--- a/modules/mail.py
+++ b/modules/mail.py
@@ -95,7 +95,7 @@ def onjoin(nick, _):
     checkmail(nick)
 
 
-def onnick(nick):
+def onnick(_, nick):
     checkmail(nick)
 
 


### PR DESCRIPTION
From time to time users are already in a channel monitored by the bot before they get their real nickname, and then notification on join doesn't take effect.
