### PR TITLE
Authorize admin only if the logged in NickServ account matches

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,6 +38,16 @@ def privmsg(receiver, text):
 
     Bot must be connected.'''
     sendmsg(config['socket'], receiver, text)
+    
+    
+def whois(nick):
+    '''RFC 1459 WHOIS information query
+
+    Query the server's information about <nick> we are allowed to see.
+
+    Bot must be connected.'''
+    if config['socket'].send('WHOIS %s\r\n' % nick) == 0:
+        raise Exception("connection")
 
 
 def sendmsg(sock, dest, text):
@@ -154,6 +164,7 @@ def loadmodules():
         mod.sanitize = sanitize
         mod.join = join
         mod.privmsg = privmsg
+        mod.whois = whois
         mod.init()
         modules_list.append(mod)  # Adding module to the list
 

--- a/bot.py
+++ b/bot.py
@@ -81,6 +81,7 @@ def onjoin(nick, channel):
 def onrpl(num, payload):
     if num == '330':
         nick, account, status = payload.split(' ', 2)
+        # this is not in the standard so we better check all static info
         if status == ':is logged in as':
             onwhois_auth(nick, account)
     elif num == '318':

--- a/bot.py
+++ b/bot.py
@@ -78,6 +78,31 @@ def onjoin(nick, channel):
             pass
 
 
+def onrpl(num, payload):
+    if num == '330':
+        nick, account, status = payload.split(' ', 2)
+        if status == ':is logged in as':
+            onwhois_auth(nick, account)
+    elif num == '318':
+        onwhois_end()
+
+
+def onwhois_auth(nick, account):
+    for i in modules_list:
+        try:
+            i.onwhois_auth(nick, account)
+        except AttributeError:
+            pass
+    
+    
+def onwhois_end():
+    for i in modules_list:
+        try:
+            i.onwhois_end()
+        except AttributeError:
+            pass
+
+
 def join(channels):
     '''Joins a list of channels'''
     for i in channels:
@@ -181,6 +206,9 @@ def main():
             nick, _, channel = data.split(' ', 3)
             nick = nick.split('!')[0].replace(':', '')
             onjoin(nick, channel)
+        elif data.startswith(':'):
+            _, rpl, _, args = data.split(' ', 4)
+            onrpl(rpl, args)
 
 if __name__ == '__main__':
     loadconf()

--- a/modules/commands.py
+++ b/modules/commands.py
@@ -29,8 +29,28 @@ def init():
     pass
 
 
+def onwhois_auth(nick, login):
+    global account
+    account = login
+
+
+def onwhois_end():
+    global done
+    done = True
+
+
+def account(nick):
+    global done, account
+    done = False
+    account = None
+    whois(nick)
+    while not done:
+        continue
+    return account
+
+
 def check(sender):
-    if sender != config['owner']:
+    if account(sender) != config['owner']
         return "%s, pensi di essere il capitano Picard?" % sender
     return None
 


### PR DESCRIPTION
Full disclosure: At the moment, if the owner is not online and someone steals her nickname she can admin the bot.

Instead, require the owner name to be the name of the account name. To steal an account name one must know the password that is associated with it.

This way we also get around implementing our own registration service.

Also see issue #7 
